### PR TITLE
Remove deprecated LOCALSTACK_HOSTNAME config

### DIFF
--- a/.env-gdc
+++ b/.env-gdc
@@ -11,6 +11,5 @@ export LS_IMAGE=localstack/localstack-pro
 export LS_ENFORCE_IAM=1
 export USE_LOCALSTACK_PERSISTENCE=no
 export LOCALSTACK_HOST=host.docker.internal
-export LOCALSTACK_HOSTNAME=host.docker.internal
 export LOCALSTACK_ENDPOINT=http://host.docker.internal:4566
 


### PR DESCRIPTION
`LOCALSTACK_HOSTNAME` is a legacy configuration and will be ignored in LocalStack >=3.0. See 
For more details, see [Networking Migration Guide for LocalStack 3.0](https://discuss.localstack.cloud/t/networking-migration-guide-for-localstack-3-0/588)

PS: Feel free to delay the cleanup if this is needed to support LocalStack <3.0.

/cc repo maintainer @cabeaulac 